### PR TITLE
Fix CollisionObject memory leak

### DIFF
--- a/fcl/fcl.pyx
+++ b/fcl/fcl.pyx
@@ -89,7 +89,7 @@ cdef class CollisionObject:
         defs.Py_INCREF(<defs.PyObject*> geom)
         self.geom = <defs.PyObject*> geom
         self._no_instance = _no_instance
-        if geom.getNodeType() is not None:
+        if geom.getNodeType() is not None and not self._no_instance:
             if tf is not None:
                 self.thisptr = new defs.CollisionObject(defs.shared_ptr[defs.CollisionGeometry](geom.thisptr), deref(tf.thisptr))
             else:

--- a/fcl/fcl.pyx
+++ b/fcl/fcl.pyx
@@ -1,3 +1,4 @@
+# cython: language_level=2
 from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.vector cimport vector


### PR DESCRIPTION
This fix addresses the usage of the `_no_instance` parameter in the `__cinit__` method for `CollisionObject`. By adding a condition that [`_no_instance is False`](https://github.com/rmumi/python-fcl/blob/6f4fe382cc1e764ea9b8a9acd62674817f1bc623/fcl/fcl.pyx#L93) for assigning new C++ objects of type `defs.CollisionObject` we avoid leaking memory and unnecessary constructor calls.

Previously the only caller to the constructor with the parameter `_no_instance` was the [`copy_ptr_collision_object`](https://github.com/BerkeleyAutomation/python-fcl/blob/43ab7108ff4c5a41966a7b6968a3d683ef05eb53/fcl/fcl.pyx#L756) function, and as soon as it does the init of a `CollisionObject`  it overwrites its internal pointer to the C++ class with the pointer from our object in the method. This did not free the allocated `defs.CollisionObject` and thus caused a leak. As this is the only call to the function where the `_no_instance` is set, a reasonable thing would be to avoid calling the unnecessary constructors, as the values are overwritten anyways.

The behavior of the API stays the same as only the [`_no_instance=True`](https://github.com/BerkeleyAutomation/python-fcl/blob/43ab7108ff4c5a41966a7b6968a3d683ef05eb53/fcl/fcl.pyx#L758) call is affected, by only removing redundancies. The [`self.thisptr.setUserData`](https://github.com/BerkeleyAutomation/python-fcl/blob/43ab7108ff4c5a41966a7b6968a3d683ef05eb53/fcl/fcl.pyx#L97) is also redundant as we get the pointer from the `self.geom` object which is set by the pointer from [`getUserData`](https://github.com/BerkeleyAutomation/python-fcl/blob/43ab7108ff4c5a41966a7b6968a3d683ef05eb53/fcl/fcl.pyx#L757) that will stay the same in the wanted object.

A minimal example of a program that continuously leaks memory is below. Without the fix the program gets to about 1.2 GB of RAM at the end (as it is constantly leaking `CollisionObject` objects), and only consumes about 44 MB for the whole execution if we remove the leak. This leak is indeed noticeable when running algorithms that do a lot of collision checks on large collision sets, such as sampling based planners.

```python
import fcl

box1 = fcl.Box(1.0, 2.0, 5)
box2 = fcl.Box(3.0, 2.0, 5)
box3 = fcl.Box(3.0, 21, 5)
col_object1 = fcl.CollisionObject(box1)
col_object2 = fcl.CollisionObject(box2)
col_object3 = fcl.CollisionObject(box3)

collision_manager = fcl.DynamicAABBTreeCollisionManager()
collision_manager.registerObjects([col_object1, col_object2])

for _ in range(1000000):
    result_data = fcl.CollisionData(
        request=fcl.CollisionRequest(), result=fcl.CollisionResult())
    collision_manager.collide(
        col_object3, result_data, fcl.defaultCollisionCallback)
```