### PR TITLE
fix updating of nearest points, etc

### DIFF
--- a/fcl/fcl.pyx
+++ b/fcl/fcl.pyx
@@ -104,6 +104,10 @@ cdef class CollisionObject:
         if self.thisptr and not self._no_instance:
             free(self.thisptr)
         defs.Py_DECREF(self.geom)
+    
+    def getCollisionGeometry(self):
+        cdef CollisionGeometry py_geom = <CollisionGeometry> ((<defs.CollisionObject*> self.thisptr).getUserData())
+        return py_geom
 
     def getObjectType(self):
         return self.thisptr.getObjectType()
@@ -618,13 +622,14 @@ def distance(CollisionObject o1, CollisionObject o2,
                                     ),
                                     cresult)
 
-    result.min_distance = min(cresult.min_distance, result.min_distance)
-    result.nearest_points = [vec3f_to_numpy(cresult.nearest_points[0]),
-                             vec3f_to_numpy(cresult.nearest_points[1])]
-    result.o1 = c_to_python_collision_geometry(cresult.o1, o1, o2)
-    result.o2 = c_to_python_collision_geometry(cresult.o2, o1, o2)
-    result.b1 = cresult.b1
-    result.b2 = cresult.b2
+    if result.min_distance > cresult.min_distance:
+        result.min_distance = cresult.min_distance
+        result.nearest_points = [vec3f_to_numpy(cresult.nearest_points[0]),
+                                vec3f_to_numpy(cresult.nearest_points[1])]
+        result.o1 = c_to_python_collision_geometry(cresult.o1, o1, o2)
+        result.o2 = c_to_python_collision_geometry(cresult.o2, o1, o2)
+        result.b1 = cresult.b1
+        result.b2 = cresult.b2
     return dis
 
 ###############################################################################


### PR DESCRIPTION
The logic of updating the nearest points, object ids, etc. in the function "distance" is problematic, resulting in wrong nearest points as described in #28. This PR provides a straightforward fix. Even though the example in the issue still does not pass, it is merely because fcl 0.5 returns the nearest points in the object frame. 

Also added a function to get the geometry object from a CollisionObject. 

This is the same fix as this [PR](https://github.com/CyrilWaechter/python-fcl/pull/1).