### PR TITLE
feat: macos arm wheels

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.7.0
+      uses: pypa/cibuildwheel@v2.12.0
+      env:
+        CIBW_ARCHS_MACOS: 'x86_64 arm64'
     - uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.4
+      uses: pypa/cibuildwheel@v2.12.0
+      env:
+        CIBW_ARCHS_MACOS: 'x86_64 arm64'
     - uses: actions/upload-artifact@v3
       with:
         path: ./wheelhouse/*.whl


### PR DESCRIPTION
This produces macos arm wheels in the github actions and upgrades the pypa/cibuildwheel to v2.12.0. [Here's a test run of push.yml](https://github.com/jackbow/python-fcl/actions/runs/3943329767).

The wheel builder action warns that the arm builds aren't able to be tested yet, but it'll release in a future version. If this is a concern it can be added to the readme as a warning for macos arm users.