### PR TITLE
feat: format and upgrade github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,18 +7,18 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-    - name: Check out source repository
-      uses: actions/checkout@v2
-    - name: Set up Python environment
-      uses: actions/setup-python@v3
-      with:
-        python-version: 3.9
-    - name: flake8
-      uses: py-actions/flake8@v2
-    - name: black
-      uses: psf/black@stable
-      with:
-        options: "--check --diff -l 90"
+      - name: Check out source repository
+        uses: actions/checkout@v3
+      - name: Set up Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: flake8
+        uses: py-actions/flake8@v2
+      - name: black
+        uses: psf/black@stable
+        with:
+          options: '--check --diff -l 90'
 
   build_wheels:
     name: Build wheel on ${{matrix.platform}}
@@ -28,9 +28,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.7.0
-    - uses: actions/upload-artifact@v3
-      with:
-        path: ./wheelhouse/*.whl
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.0
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v5.1
+        uses: tj-actions/changed-files@v35.4.1
       - name: Tag Version
         if: contains(steps.changed-files.outputs.modified_files, 'src/fcl/version.py')
         id: set_tag
         run: |
           export VER=v$(python -c "exec(open('src/fcl/version.py','r').read());print(__version__)")
-          echo "::set-output name=tag_name::${VER}"
+          echo echo "tag_name=${VER}" >> $GITHUB_OUTPUT
       - name: Create Release
         if: contains(steps.changed-files.outputs.modified_files, 'src/fcl/version.py')
         id: create_release
@@ -46,21 +46,21 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.11.4
-    - uses: actions/upload-artifact@v3
-      with:
-        path: ./wheelhouse/*.whl
-    - uses: xresloader/upload-to-github-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        file: ./wheelhouse/*.whl
-        overwrite: true
-        draft: false
-        update_latest_release: true
-  
+      - uses: actions/checkout@v3
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.12.0
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+      - uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          file: ./wheelhouse/*.whl
+          overwrite: true
+          draft: false
+          update_latest_release: true
+
   upload_pypi:
     if: contains(needs.create_release.outputs.mod_files, 'src/fcl/version.py')
     needs: [create_release, build_wheels]
@@ -70,7 +70,7 @@ jobs:
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.5.0
+      - uses: pypa/gh-action-pypi-publish@v1.6.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This upgrades github action versions, formats the yaml files, and updates the `echo "::set-output name={name}::{value}"` syntax per this blogpost:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/