### PR TITLE
Support Cython 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
 	"setuptools",
 	"wheel",
-	"Cython<3.0",
+	"Cython",
 	"numpy; python_version<'3.12'",
 	"numpy>=1.26.0b1; python_version>='3.12'"]
 build-backend = "setuptools.build_meta"

--- a/src/fcl/fcl_defs.pxd
+++ b/src/fcl/fcl_defs.pxd
@@ -248,8 +248,8 @@ cdef extern from "fcl/geometry/shape/plane.h" namespace "fcl":
         double d
 
 cdef extern from "fcl/broadphase/broadphase_collision_manager.h" namespace "fcl":
-    ctypedef bool (*CollisionCallBack)(CollisionObjectd* o1, CollisionObjectd* o2, void* cdata)
-    ctypedef bool (*DistanceCallBack)(CollisionObjectd* o1, CollisionObjectd* o2, void* cdata, double& dist)
+    ctypedef bool (*CollisionCallBack)(CollisionObjectd* o1, CollisionObjectd* o2, void* cdata) except? -1
+    ctypedef bool (*DistanceCallBack)(CollisionObjectd* o1, CollisionObjectd* o2, void* cdata, double& dist) except? -1
 
 cdef extern from "fcl/broadphase/broadphase_dynamic_AABB_tree.h" namespace "fcl":
     cdef cppclass DynamicAABBTreeCollisionManagerd:


### PR DESCRIPTION
Add exception specifications to callback function pointer typedefs.

This seems to be the only change that is needed. I’m working on a package for Fedora Linux, and with this patch, it builds with Cython 3 and all of the tests pass.