### PR TITLE
Wheel Builds For 3.13

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -16,7 +16,7 @@ jobs:
       - name: ruff
         run: |
           pip install ruff
-          ruff .
+          ruff check .
 
   build_wheels:
     name: Build wheel on ${{matrix.platform}}
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+        platform: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,3 +32,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: wheels-${{ matrix.runs-on }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,9 +26,9 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,7 +15,7 @@ jobs:
           python-version: "3.12"
       - name: ruff
         run: |
-          pip install ruff
+          pip install ruff==0.9.6
           ruff check .
 
   build_wheels:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels-${{ matrix.runs-on }}
+          name: wheels-${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
-          name: wheels-${{ matrix.runs-on }}
+          name: wheels-${{ matrix.platform }}
 
   upload_pypi:
     name: Release To PyPi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.22.0
       - uses: actions/upload-artifact@v3
         with:
           path: ./wheelhouse/*.whl
@@ -24,15 +24,19 @@ jobs:
     name: Release To PyPi
     needs: [build_wheels]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
-      - uses: actions/download-artifact@v3
-        with:
-          name: artifact
-          path: dist
-      - uses: pypa/gh-action-pypi-publish@v1.6.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.12"
+
+    - uses: actions/download-artifact@v3
+      with:
+        name: artifact
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@v1.8.10
 
   create_release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
 
@@ -31,7 +31,7 @@ jobs:
       with:
         python-version: "3.12"
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: artifact
         path: dist
@@ -44,7 +44,7 @@ jobs:
     needs: [build_wheels]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Tag Version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl
+          name: wheels-${{ matrix.runs-on }}
 
   upload_pypi:
     name: Release To PyPi
@@ -33,9 +34,9 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: artifact
         path: dist
-
+        pattern: wheels-*
+        merge-multiple: true
     - uses: pypa/gh-action-pypi-publish@v1.8.10
 
   create_release:
@@ -54,8 +55,9 @@ jobs:
           echo "tag_name=${VER}" >> $GITHUB_OUTPUT
       - uses: actions/download-artifact@v3
         with:
-          name: artifact
           path: dist
+          pattern: wheels-*
+          merge-multiple: true
       - uses: ncipollo/release-action@v1.14.0
         with:
           artifacts: "dist/*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{matrix.platform}}
     strategy:
       matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest, macos-14]
+        platform: [ubuntu-latest, macos-latest, windows-latest, macos-13]
     steps:
       - uses: actions/checkout@v3
       - name: Build wheels

--- a/build_dependencies/install_macos.sh
+++ b/build_dependencies/install_macos.sh
@@ -1,20 +1,44 @@
-# prevent brew from auto cleanup
-export HOMEBREW_NO_INSTALL_CLEANUP=1
+# exit immediately on any failed step
+set -xe
 
-brew install fcl
+mkdir -p deps
+cd deps
 
-# mkdir -p deps
-# cd deps
-# # Octomap
-# git clone https://github.com/OctoMap/octomap
-# cd octomap
-# git checkout tags/v1.8.0
-# mkdir build
-# cd build
-# cmake ..
-# make
-# sudo make install
+curl -OL https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz
+tar -zxf eigen-3.3.9.tar.gz
 
-# cd ..
-# cd ..
-# cd ..
+rm -rf libccd
+git clone --depth 1 --branch v2.1 https://github.com/danfis/libccd.git
+
+rm -rf octomap
+git clone --depth 1 --branch v1.9.8 https://github.com/OctoMap/octomap.git
+
+rm -rf fcl
+git clone --depth 1 --branch v0.7.0 https://github.com/ambi-robotics/fcl.git
+
+# Install eigen
+cmake -B build -S eigen-3.3.9
+cmake --install build
+
+# Build and install libccd
+cd libccd
+cmake . -D ENABLE_DOUBLE_PRECISION=ON
+make -j4
+make install
+cd ..
+
+# Build and install octomap
+cd octomap
+cmake . -D CMAKE_BUILD_TYPE=Release -D BUILD_OCTOVIS_SUBPROJECT=OFF -D BUILD_DYNAMICETD3D_SUBPROJECT=OFF
+make -j4
+make install
+cd ..
+
+# Build and install fcl
+cd fcl
+cmake .
+make -j4
+make install
+cd ..
+
+cd ..

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,5 +1,6 @@
-import fcl
 import numpy as np
+
+import fcl
 
 
 def print_collision_result(o1_name, o2_name, result):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ archs = ["x86_64"]
 [tool.cibuildwheel.macos]
 before-all = "bash build_dependencies/install_macos.sh"
 environment = { CPATH = "$(brew --prefix)/include:$(brew --prefix)/include/eigen3", LD_LIBRARY_PATH = "$(brew --prefix)/lib" }
-repair-wheel-command = "MACOSX_DEPLOYMENT_TARGET=13 delocate-wheel -w {dest_dir} -v {wheel}"
+repair-wheel-command = "delocate-wheel -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
 before-all = "powershell build_dependencies\\install_windows.ps1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,8 +108,9 @@ archs = ["x86_64"]
 [tool.cibuildwheel.macos]
 before-all = "bash build_dependencies/install_macos.sh"
 environment = { CPATH = "$(brew --prefix)/include:$(brew --prefix)/include/eigen3", LD_LIBRARY_PATH = "$(brew --prefix)/lib" }
+repair-wheel-command = "MACOSX_DEPLOYMENT_TARGET=14 delocate-wheel -w {dest_dir} -v {wheel}"
+
 
 [tool.cibuildwheel.windows]
 before-all = "powershell build_dependencies\\install_windows.ps1"
 archs = ["AMD64"]
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
 	"setuptools",
 	"wheel",
-	"Cython<3.0",
+	"Cython>=3.0",
 	"numpy; python_version<'3.12'",
 	"numpy>=1.26.0b1; python_version>='3.12'"]
 build-backend = "setuptools.build_meta"
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "python-fcl"
 description = "Python bindings for the Flexible Collision Library"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 authors = [
     {name = "Jelle Feringa", email = "jelleferinga@gmail.com"},
     {name = "Matthew Matl", email = "mmatl@eecs.berkeley.edu"},
@@ -108,8 +108,7 @@ archs = ["x86_64"]
 [tool.cibuildwheel.macos]
 before-all = "bash build_dependencies/install_macos.sh"
 environment = { CPATH = "$(brew --prefix)/include:$(brew --prefix)/include/eigen3", LD_LIBRARY_PATH = "$(brew --prefix)/lib" }
-repair-wheel-command = "MACOSX_DEPLOYMENT_TARGET=14 delocate-wheel -w {dest_dir} -v {wheel}"
-
+repair-wheel-command = "MACOSX_DEPLOYMENT_TARGET=13 delocate-wheel -w {dest_dir} -v {wheel}"
 
 [tool.cibuildwheel.windows]
 before-all = "powershell build_dependencies\\install_windows.ps1"

--- a/src/fcl/fcl.pyx
+++ b/src/fcl/fcl.pyx
@@ -761,10 +761,10 @@ cdef class DistanceFunction:
         (&dist)[0] = <double?> py_r[1]
         return <bool?> py_r[0]
 
-cdef inline bool CollisionCallBack(defs.CollisionObjectd*o1, defs.CollisionObjectd*o2, void*cdata):
+cdef inline bool CollisionCallBack(defs.CollisionObjectd*o1, defs.CollisionObjectd*o2, void*cdata) noexcept:
     return (<CollisionFunction> cdata).eval_func(o1, o2)
 
-cdef inline bool DistanceCallBack(defs.CollisionObjectd*o1, defs.CollisionObjectd*o2, void*cdata, double& dist):
+cdef inline bool DistanceCallBack(defs.CollisionObjectd*o1, defs.CollisionObjectd*o2, void*cdata, double& dist) noexcept:
     return (<DistanceFunction> cdata).eval_func(o1, o2, dist)
 
 

--- a/tests/test_fcl.py
+++ b/tests/test_fcl.py
@@ -1,7 +1,8 @@
 import unittest
 
-import fcl
 import numpy as np
+
+import fcl
 
 
 class TestFCL(unittest.TestCase):

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -1,7 +1,8 @@
 import unittest
 
-import fcl
 import numpy as np
+
+import fcl
 
 
 # These test cases were added because there was a very sneaky crash that would occur


### PR DESCRIPTION
This updates cibuildwheel to build for Python 3.13 and release with support for Numpy 2.

PyPi releases to `pip install python-fcl` have been blocked by a PyPi token for a while. To fix it, this repo would need to be added as a trusted publisher on `PyPi`. I can merge on this repo, but I would have to be added to the [PyPi project](https://pypi.org/project/python-fcl/) to fix the publishing.

In the interim, I released my branch as `pip install fclx`, which provides the same import module `import fcl` as this repo and has [wheels for major platforms](https://pypi.org/project/fclx/#files). If people don't object too much to a name change (`python-fcl` -> `fclx`) I'd be happy to make that change on this repo to get the wheels releasing again.

Additional build changes:
- Updates supported version range to 3.9-3.13, dropping 3.7/3.8
- Makes minor changes to support Cython 3. I'm not sure why it's different than #77 but the build succeeds and tests pass. 
- Changes Mac build to compile FCL rather than pulling it from brew, as I was having version mismatch issues, and the only advantage to using brew seems like build time?
- fixes CI by updating deprecated actions