### PR TITLE
Update cibuildwheel to v3.1.1 to support Python 3.14 

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.1
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@v3.1.1
       - uses: actions/upload-artifact@v4
         with:
           path: ./wheelhouse/*.whl


### PR DESCRIPTION
This PR updates `cibuildwheel` to version 3.1.1 in both the push.yml and release.yml GitHub workflows.
The update is needed to enable building wheels for Python 3.14.
